### PR TITLE
Tell ES how to type the event

### DIFF
--- a/cookbooks/simplerock/templates/default/kafka-bro.conf.erb
+++ b/cookbooks/simplerock/templates/default/kafka-bro.conf.erb
@@ -22,6 +22,7 @@ output {
       host => "127.0.0.1"
       cluster => "elasticsearch"
       protocol => "node"
+      document_type => "%{sensor_logtype}"
       #flush_size => 1000
     }
   }


### PR DESCRIPTION
If we type the event by the type of log, we reduce namespace collisions on field names w/ clashing data types. This makes the mapping of the data much, much cleaner.