### PR TITLE
added service modes and updated recipe

### DIFF
--- a/cookbooks/simplerock/recipes/default.rb
+++ b/cookbooks/simplerock/recipes/default.rb
@@ -835,6 +835,23 @@ template '/usr/local/bin/rock_status' do
 end
 
 ######################################################
+############### Service Mode Scripts #################
+######################################################
+template '/usr/local/bin/training_mode' do
+  source 'training_mode.erb'
+  mode '0700'
+  owner 'root'
+  group 'root'
+end
+
+template '/usr/local/bin/service_mode' do
+  source 'status_mode.erb'
+  mode '0700'
+  owner 'root'
+  group 'root'
+end
+
+######################################################
 ############### Configure Stenographer ###############
 ######################################################
 template '/etc/stenographer/config' do

--- a/cookbooks/simplerock/templates/default/service_mode.erb
+++ b/cookbooks/simplerock/templates/default/service_mode.erb
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+export MON_IFS=$(cat /opt/bro/etc/node.cfg | grep interface | \
+        sed 's/interface=//' | paste -sd " " -)
+
+echo "Entering Service Mode..."
+echo "options pf_ring transparent_mode=0 enable_tx_capture=0 min_num_slots=65534" > /etc/modprobe.d/pf_ring.conf
+rock_stop
+ifdown $MON_IFS
+modprobe -r pf_ring; modprobe pf_ring
+ifup $MON_IFS
+rock_start
+rock_status
+sleep 5
+echo "Entered Service Mode"

--- a/cookbooks/simplerock/templates/default/training_mode.erb
+++ b/cookbooks/simplerock/templates/default/training_mode.erb
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+export MON_IFS=$(cat /opt/bro/etc/node.cfg | grep interface | \
+        sed 's/interface=//' | paste -sd " " -)
+
+echo "Entering Training Mode..."
+echo "options pf_ring transparent_mode=0 enable_tx_capture=1 min_num_slots=65534" > /etc/modprobe.d/pf_ring.conf
+rock_stop
+ifdown $MON_IFS
+modprobe -r pf_ring; modprobe pf_ring
+ifup $MON_IFS
+rock_start
+rock_status
+sleep 5
+echo "Entered Training Mode"


### PR DESCRIPTION
Added 2 scripts for different operating modes:  
* training mode - used for training purposes to allow transmit over the listening interface
* service mode - used during production usage to prevent data bleed over the listening interface

Updated the recipe to build these scripts.