### PR TITLE
Bug fixes and package migration

### DIFF
--- a/cookbooks/packagecloud/.gitignore
+++ b/cookbooks/packagecloud/.gitignore
@@ -1,0 +1,19 @@
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+pkg/
+
+# Berkshelf
+.vagrant
+/cookbooks
+Berksfile.lock
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen

--- a/cookbooks/packagecloud/.kitchen.yml
+++ b/cookbooks/packagecloud/.kitchen.yml
@@ -1,0 +1,79 @@
+---
+driver_plugin: vagrant
+driver_config:
+  require_chef_omnibus: true
+
+platforms:
+- name: ubuntu-10.04
+  driver_config:
+    box: opscode-ubuntu-10.04
+    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-10.04_provisionerless.box
+  run_list:
+    - recipe[packagecloud_test::lucid_deps]
+    - recipe[packagecloud_test::deb]
+    - recipe[packagecloud_test::rubygems_private]
+
+- name: ubuntu-12.04
+  driver_config:
+    box: opscode-ubuntu-12.04
+    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box
+  run_list:
+    - recipe[packagecloud_test::precise_deps]
+    - recipe[packagecloud_test::deb]
+    - recipe[packagecloud_test::rubygems_private]
+
+- name: ubuntu-14.04
+  driver_config:
+    box: opscode-ubuntu-14.04
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box
+  run_list:
+    - recipe[packagecloud_test::trusty_deps]
+    - recipe[packagecloud_test::deb]
+    - recipe[packagecloud_test::rubygems]
+
+- name: centos-without-epel-5.10
+  driver_config:
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-5.10_chef-provisionerless.box
+  run_list:
+    - recipe[packagecloud_test::rpm]
+    - recipe[packagecloud_test::rubygems]
+
+- name: centos-with-epel-5.10
+  driver_config:
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-5.10_chef-provisionerless.box
+  run_list:
+    - recipe[packagecloud_test::epel5]
+    - recipe[packagecloud_test::rpm]
+    - recipe[packagecloud_test::rubygems_private]
+
+- name: centos-6.5
+  run_list:
+    - recipe[packagecloud_test::rpm]
+    - recipe[packagecloud_test::rubygems]
+
+- name: centos-7.0
+  run_list:
+    - recipe[packagecloud_test::rpm]
+    - recipe[packagecloud_test::rubygems_private]
+
+- name: amazon-2014.09
+  driver_plugin: ec2
+  driver_config:
+    image_id: ami-b5a7ea85
+    username: ec2-user
+    aws_access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+    aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+    aws_ssh_key_id: <%= ENV['AWS_KEYPAIR_NAME'] %>
+    ssh_key: <%= ENV['AWS_SSH_KEY_PATH'] %>
+    availability_zone: us-west-2a
+    region: us-west-2
+    flavor_id: t2.micro
+    security_group_ids: sg-598e583c
+  run_list:
+    - recipe[packagecloud_test::rpm]
+    - recipe[packagecloud_test::rubygems]
+
+suites:
+- name: default
+  run_list:
+  attributes: {}

--- a/cookbooks/packagecloud/.rubocop.yml
+++ b/cookbooks/packagecloud/.rubocop.yml
@@ -1,0 +1,28 @@
+AllCops:
+  Include:
+    - Berksfile
+    - Gemfile
+    - Rakefile
+    - Thorfile
+    - Guardfile
+  Exclude:
+    - vendor/**
+
+ClassLength:
+  Enabled: false
+Documentation:
+  Enabled: false
+Encoding:
+  Enabled: false
+HashSyntax:
+  Enabled: false
+LineLength:
+  Enabled: false
+MethodLength:
+  Enabled: false
+SignalException:
+  Enabled: false
+TrailingComma:
+  Enabled: false
+WordArray:
+  Enabled: false

--- a/cookbooks/packagecloud/.travis.yml
+++ b/cookbooks/packagecloud/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 2.0.0
+bundler_args: --without integration
+script:
+  - bundle exec rake travis

--- a/cookbooks/packagecloud/Berksfile
+++ b/cookbooks/packagecloud/Berksfile
@@ -1,0 +1,5 @@
+source 'https://api.berkshelf.com'
+
+metadata
+
+cookbook 'packagecloud_test', :path => 'test/fixtures/cookbooks/packagecloud_test'

--- a/cookbooks/packagecloud/CHANGELOG.md
+++ b/cookbooks/packagecloud/CHANGELOG.md
@@ -1,0 +1,54 @@
+packagecloud
+===============
+This is the Changelog for the packagecloud cookbook
+
+v0.2.5 (2016-08-11)
+-------------------
+Check for empty node hostname. Display error when a node's fully qualified hostname
+is not set; as returned by `hostname -f`
+
+v0.2.4 (2016-07-05)
+-------------------
+Add `proxy_host` and `proxy_port` attributes so that the cookbook can contact the
+packagecloud server.
+
+v0.2.3 (2016-06-01)
+-------------------
+Try to fix `metadata_expire` type (set as String)
+
+v0.2.2 (2016-06-01)
+-------------------
+Try to fix `metadata_expire` type (set as Integer)
+
+v0.2.1 (2016-05-31)
+-------------------
+Set `metadata_expire` option to default of 300 (5 minutes) to match the
+generated configs produced by the bash and manual install instructions.
+
+
+v0.2.0 (2016-02-17)
+-------------------
+Rework GPG paths to support new GPG endpoints for repos with repo-specific GPG
+keys. Old endpoints/URLs still work, too.
+
+v0.1.0 (2015-09-08)
+-------------------
+packagecloud cookbook versions 0.0.19 used an attribute called
+`default['packagecloud']['hostname']` for caching the local machine's hostname
+to avoid regenerating read tokens.
+
+This attribute has been removed as it is confusing and in some edge cases,
+buggy.
+
+Beginning in 0.1.0, you can use
+`default['packagecloud']['hostname_override']` to specify a hostname if ohai
+is unable to determine the hostname of the node on its own.
+
+v0.0.1 (2014-06-05)
+-------------------
+Initial release.
+
+
+v0.0.1 (2014-06-05)
+-------------------
+Initial release!

--- a/cookbooks/packagecloud/Gemfile
+++ b/cookbooks/packagecloud/Gemfile
@@ -1,0 +1,16 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'berkshelf', '~> 3.1.4'
+gem 'kitchen-ec2'
+gem 'stove'
+
+group :test do
+  gem 'foodcritic', '~> 4.0.0'
+  gem 'rubocop', '~> 0.24.1'
+end
+
+group :integration do
+  gem 'test-kitchen', '~> 1.2.1'
+  gem 'kitchen-vagrant', '~> 0.15.0'
+end

--- a/cookbooks/packagecloud/LICENSE
+++ b/cookbooks/packagecloud/LICENSE
@@ -1,0 +1,13 @@
+Copyright (C) 2014 Computology, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/cookbooks/packagecloud/README.md
+++ b/cookbooks/packagecloud/README.md
@@ -1,0 +1,91 @@
+# packagecloud cookbook
+
+This cookbook provides an LWRP for installing https://packagecloud.io repositories.
+
+NOTE: Please see the Changelog below for important changes if upgrading from 0.0.19 to 0.1.0.
+
+## Usage
+
+Be sure to depend on `packagecloud` in `metadata.rb` so that the packagecloud
+resource will be loaded.
+
+For public repos:
+
+```ruby
+packagecloud_repo "computology/packagecloud-cookbook-test-public" do
+  type "deb"
+end
+```
+
+For private repos, you need to supply a `master_token`:
+
+```ruby
+packagecloud_repo "computology/packagecloud-cookbook-test-private" do
+  type "deb"
+  master_token "762748f7ae0bfdb086dd539575bdc8cffdca78c6a9af0db9"
+end
+```
+
+For packagecloud:enterprise users, add `base_url` to your resource:
+
+```
+packagecloud_repo "computology/packagecloud-cookbook-test-private" do
+  base_url "https://packages.example.com"
+  type "deb"
+  master_token "762748f7ae0bfdb086dd539575bdc8cffdca78c6a9af0db9"
+end
+```
+
+For forcing the os and dist for repository install:
+
+```
+packagecloud_repo 'computology/packagecloud-cookbook-test-public' do
+  type 'rpm'
+  force_os 'rhel'
+  force_dist '6.5'
+end
+```
+
+Valid options for `type` include `deb`, `rpm`, and `gem`.
+
+This cookbook performs checks to determine if a package exists before attempting
+to install it. To enable proxy support *for these checks* (not to be confused
+with proxy support for your package manager of choice), add the following
+attributes to your cookbook:
+
+```
+default['packagecloud']['proxy_host'] = 'myproxy.organization.com'
+default['packagecloud']['proxy_port'] = '80'
+```
+
+## Interactions with other cookbooks
+
+On CentOS 5, the official chef yum cookbook overwrites the file
+`/etc/yum.conf` setting some default values. When it does this, the `cachedir`
+value is changed from the CentOS5 default to the default value in the
+cookbook. The result of this change is that any packagecloud repository
+installed *before* a repository installed with the yum cookbook will appear as
+though it's gpg keys were not imported.
+
+There are a few potential workarounds for this:
+
+- Pass the "-y" flag to package resource using the `options` attribute. This
+  should cause yum to import the GPG key automatically if it was not imported
+  already.
+- Move your packagecloud repos so that they are installed last, after any/all
+  repos installed via the yum cookbook.
+- Set the cachedir option in the chef yum cookbook to the system default value
+  of `/var/cache/yum` using the `yum_globalconfig` resource.
+
+CentOS 6 and 7 are not affected as the default `cachedir` value provided by
+the yum chef cookbook is set to the system default, unless you use the
+`yum_globalconfig` resource to set a custom cachedir. If you do set a custom
+`cachedir`, you should make sure to setup packagecloud repos after that
+resource is set so that the GPG keys end up in the right place.
+
+## Changelog
+
+See CHANGELOG.md for more recent changes.
+
+## Credits
+Computology, LLC.

--- a/cookbooks/packagecloud/Rakefile
+++ b/cookbooks/packagecloud/Rakefile
@@ -1,0 +1,47 @@
+#!/usr/bin/env rake
+
+# Style tests. Rubocop and Foodcritic
+namespace :style do
+  begin
+    require 'rubocop/rake_task'
+    desc 'Run Ruby style checks'
+    RuboCop::RakeTask.new(:ruby)
+  rescue LoadError
+    puts '>>>>> Rubocop gem not loaded, omitting tasks' unless ENV['CI']
+  end
+
+  begin
+    require 'foodcritic'
+
+    desc 'Run Chef style checks'
+    FoodCritic::Rake::LintTask.new(:chef) do |t|
+      t.options = {
+        fail_tags: ['any'],
+        tags: ['~FC003']
+      }
+    end
+  rescue LoadError
+    puts '>>>>> foodcritic gem not loaded, omitting tasks' unless ENV['CI']
+  end
+end
+
+desc 'Run all style checks'
+task style: ['style:chef', 'style:ruby']
+
+# Integration tests. Kitchen.ci
+namespace :integration do
+  begin
+    require 'kitchen/rake_tasks'
+
+    desc 'Run kitchen integration tests'
+    Kitchen::RakeTasks.new
+  rescue LoadError
+    puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
+  end
+end
+
+desc 'Run all tests on Travis'
+task travis: ['style']
+
+# Default
+task default: ['style', 'integration:kitchen:all']

--- a/cookbooks/packagecloud/THANKS
+++ b/cookbooks/packagecloud/THANKS
@@ -1,0 +1,6 @@
+The following people have contributed to packagecloud chef cookbook (If you're not listed here and you should be, please let us know!):
+
+THANKS
+------
+Guilhem Lettron (@guilhem)
+Michael S. Fischer (@mfischer-zd)

--- a/cookbooks/packagecloud/Thorfile
+++ b/cookbooks/packagecloud/Thorfile
@@ -1,0 +1,5 @@
+# encoding: utf-8
+
+require 'bundler'
+require 'bundler/setup'
+require 'berkshelf/thor'

--- a/cookbooks/packagecloud/Vagrantfile
+++ b/cookbooks/packagecloud/Vagrantfile
@@ -1,0 +1,85 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.require_version ">= 1.5.0"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  config.vm.hostname = "packagecloud-berkshelf"
+
+  # Set the version of chef to install using the vagrant-omnibus plugin
+  config.omnibus.chef_version = :latest
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "opscode_ubuntu-12.04_provisionerless"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  config.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box"
+
+  # Assign this VM to a host-only network IP, allowing you to access it
+  # via the IP. Host-only networks can talk to the host machine as well as
+  # any other machines on the same network, but cannot be accessed (through this
+  # network interface) by any external networks.
+  config.vm.network :private_network, type: "dhcp"
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider :virtualbox do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
+  # end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  # The path to the Berksfile to use with Vagrant Berkshelf
+  # config.berkshelf.berksfile_path = "./Berksfile"
+
+  # Enabling the Berkshelf plugin. To enable this globally, add this configuration
+  # option to your ~/.vagrant.d/Vagrantfile file
+  config.berkshelf.enabled = true
+
+  # An array of symbols representing groups of cookbook described in the Vagrantfile
+  # to exclusively install and copy to Vagrant's shelf.
+  # config.berkshelf.only = []
+
+  # An array of symbols representing groups of cookbook described in the Vagrantfile
+  # to skip installing and copying to Vagrant's shelf.
+  # config.berkshelf.except = []
+
+  config.vm.provision :chef_solo do |chef|
+    chef.json = {
+      mysql: {
+        server_root_password: 'rootpass',
+        server_debian_password: 'debpass',
+        server_repl_password: 'replpass'
+      }
+    }
+
+    chef.run_list = [
+        "recipe[packagecloud::default]"
+    ]
+  end
+end

--- a/cookbooks/packagecloud/attributes/default.rb
+++ b/cookbooks/packagecloud/attributes/default.rb
@@ -1,0 +1,10 @@
+default['packagecloud']['base_repo_path'] = "/install/repositories/"
+default['packagecloud']['gpg_key_path'] = "/gpgkey"
+default['packagecloud']['hostname_override'] = nil
+default['packagecloud']['proxy_host'] = nil
+default['packagecloud']['proxy_port'] = nil
+
+default['packagecloud']['default_type'] = value_for_platform_family(
+  'debian' => 'deb',
+  ['rhel', 'fedora'] => 'rpm'
+)

--- a/cookbooks/packagecloud/chefignore
+++ b/cookbooks/packagecloud/chefignore
@@ -1,0 +1,98 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+CHANGELOG*
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml
+
+# tmux #
+##########
+.tmux

--- a/cookbooks/packagecloud/libraries/helper.rb
+++ b/cookbooks/packagecloud/libraries/helper.rb
@@ -1,0 +1,43 @@
+require 'net/https'
+
+module PackageCloud
+  module Helper
+    def get(uri, params)
+      uri.query     = URI.encode_www_form(params)
+      req           = Net::HTTP::Get.new(uri.request_uri)
+
+      req.basic_auth uri.user, uri.password if uri.user
+
+      http = Net::HTTP.new(uri.hostname, uri.port, node['packagecloud']['proxy_host'], node['packagecloud']['proxy_port'])
+      http.use_ssl = true
+
+      resp = http.start { |h| h.request(req) }
+
+      case resp
+      when Net::HTTPSuccess
+        resp
+      else
+        raise resp.inspect
+      end
+    end
+
+    def post(uri, params)
+      req           = Net::HTTP::Post.new(uri.request_uri)
+      req.form_data = params
+
+      req.basic_auth uri.user, uri.password if uri.user
+
+      http = Net::HTTP.new(uri.hostname, uri.port, node['packagecloud']['proxy_host'], node['packagecloud']['proxy_port'])
+      http.use_ssl = true
+
+      resp = http.start { |h|  h.request(req) }
+
+      case resp
+      when Net::HTTPSuccess
+        resp
+      else
+        raise resp.inspect
+      end
+    end
+  end
+end

--- a/cookbooks/packagecloud/libraries/matcher.rb
+++ b/cookbooks/packagecloud/libraries/matcher.rb
@@ -1,0 +1,7 @@
+if defined?(ChefSpec)
+
+  def create_packagecloud_repo(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:packagecloud_repo, :add, resource_name)
+  end
+
+end

--- a/cookbooks/packagecloud/metadata.json
+++ b/cookbooks/packagecloud/metadata.json
@@ -1,0 +1,42 @@
+{
+  "name": "packagecloud",
+  "description": "Installs/Configures packagecloud.io repositories.",
+  "long_description": "Installs/Configures packagecloud.io repositories.",
+  "maintainer": "Joe Damato",
+  "maintainer_email": "joe@packagecloud.io",
+  "license": "Apache 2.0",
+  "platforms": {
+
+  },
+  "dependencies": {
+
+  },
+  "recommendations": {
+
+  },
+  "suggestions": {
+
+  },
+  "conflicting": {
+
+  },
+  "providing": {
+
+  },
+  "replacing": {
+
+  },
+  "attributes": {
+
+  },
+  "groupings": {
+
+  },
+  "recipes": {
+
+  },
+  "version": "0.2.5",
+  "source_url": "https://github.com/computology/packagecloud-cookbook",
+  "issues_url": "https://github.com/computology/packagecloud-cookbook/issues",
+  "privacy": false
+}

--- a/cookbooks/packagecloud/metadata.rb
+++ b/cookbooks/packagecloud/metadata.rb
@@ -1,0 +1,9 @@
+name 'packagecloud'
+maintainer 'Joe Damato'
+maintainer_email 'joe@packagecloud.io'
+license 'Apache 2.0'
+description 'Installs/Configures packagecloud.io repositories.'
+long_description 'Installs/Configures packagecloud.io repositories.'
+version '0.2.5'
+source_url 'https://github.com/computology/packagecloud-cookbook' if respond_to?(:source_url)
+issues_url 'https://github.com/computology/packagecloud-cookbook/issues' if respond_to?(:issues_url)

--- a/cookbooks/packagecloud/providers/repo.rb
+++ b/cookbooks/packagecloud/providers/repo.rb
@@ -1,0 +1,224 @@
+include ::PackageCloud::Helper
+
+require 'uri'
+
+use_inline_resources if defined?(use_inline_resources)
+
+action :add do
+  case new_resource.type
+  when 'deb'
+    install_deb
+  when 'rpm'
+    install_rpm
+  when 'gem'
+    install_gem
+  else
+    raise "#{new_resource.type} is an unknown package type."
+  end
+end
+
+def gpg_url(base_url, repo, format, master_token)
+  base_install_url = ::File.join(base_url, node['packagecloud']['base_repo_path'])
+  ext = (format == :deb) ? 'list' : 'repo'
+  gpg_key_url_endpoint = construct_uri_with_options({base_url: base_install_url, repo: repo, endpoint: "gpg_key_url.#{ext}"})
+  if !master_token.nil?
+    gpg_key_url_endpoint.user = master_token
+    gpg_key_url_endpoint.password = ''
+  end
+
+  URI(get(gpg_key_url_endpoint, install_endpoint_params).body.chomp)
+end
+
+def install_deb
+  base_url = new_resource.base_url
+  repo_url = construct_uri_with_options({base_url: base_url, repo: new_resource.repository, endpoint: node['platform']})
+
+  Chef::Log.debug("#{new_resource.name} deb repo url = #{repo_url}")
+
+  package 'wget'
+  package 'apt-transport-https'
+
+  repo_url = read_token(repo_url)
+
+  template "/etc/apt/sources.list.d/#{filename}.list" do
+    source 'apt.erb'
+    cookbook 'packagecloud'
+    mode '0644'
+    variables :base_url     => repo_url.to_s,
+              :distribution => node['lsb']['codename'],
+              :component    => 'main'
+
+    notifies :run, "execute[apt-key-add-#{filename}]", :immediately
+    notifies :run, "execute[apt-get-update-#{filename}]", :immediately
+  end
+
+  gpg_url = gpg_url(new_resource.base_url, new_resource.repository, :deb, new_resource.master_token)
+
+  execute "apt-key-add-#{filename}" do
+    command "wget --auth-no-challenge -qO - #{gpg_url.to_s} | apt-key add -"
+    action :nothing
+  end
+
+  execute "apt-get-update-#{filename}" do
+    command "apt-get update -o Dir::Etc::sourcelist=\"sources.list.d/#{filename}.list\"" \
+            " -o Dir::Etc::sourceparts=\"-\"" \
+            " -o APT::Get::List-Cleanup=\"0\""
+    action :nothing
+  end
+end
+
+def install_rpm
+  given_base_url = new_resource.base_url
+  base_repo_url = ::File.join(given_base_url, node['packagecloud']['base_repo_path'])
+  base_url_endpoint = construct_uri_with_options({base_url: base_repo_url, repo: new_resource.repository, endpoint: 'rpm_base_url'})
+
+  if new_resource.master_token
+    base_url_endpoint.user     = new_resource.master_token
+    base_url_endpoint.password = ''
+  end
+
+  base_url = URI(get(base_url_endpoint, install_endpoint_params).body.chomp)
+
+  Chef::Log.debug("#{new_resource.name} rpm base url = #{base_url}")
+
+  package 'pygpgme' do
+    ignore_failure true
+  end
+
+  log 'pygpgme_warning' do
+    message 'The pygpgme package could not be installed. This means GPG verification is not possible for any RPM installed on your system. ' \
+            'To fix this, add a repository with pygpgme. Usualy, the EPEL repository for your system will have this. ' \
+            'More information: https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F and https://github.com/opscode-cookbooks/yum-epel'
+
+    level :warn
+    not_if 'rpm -qa | grep -qw pygpgme'
+  end
+
+  ruby_block 'disable repo_gpgcheck if no pygpgme' do
+    block do
+      template = run_context.resource_collection.find(:template => "/etc/yum.repos.d/#{filename}.repo")
+      template.variables[:repo_gpgcheck] = 0
+    end
+    not_if 'rpm -qa | grep -qw pygpgme'
+  end
+
+  gpg_url = gpg_url(new_resource.base_url, new_resource.repository, :rpm, new_resource.master_token)
+
+  template "/etc/yum.repos.d/#{filename}.repo" do
+    source 'yum.erb'
+    cookbook 'packagecloud'
+    mode '0644'
+    variables :base_url        => base_url.to_s,
+              :name            => filename,
+              :gpg_url         => gpg_url.to_s,
+              :repo_gpgcheck   => 1,
+              :description     => filename,
+              :priority        => new_resource.priority,
+              :metadata_expire => new_resource.metadata_expire
+
+    notifies :run, "execute[yum-makecache-#{filename}]", :immediately
+    notifies :create, "ruby_block[yum-cache-reload-#{filename}]", :immediately
+  end
+
+  # get the metadata for this repo only
+  execute "yum-makecache-#{filename}" do
+    command "yum -q makecache -y --disablerepo=* --enablerepo=#{filename}"
+    action :nothing
+  end
+
+  # reload internal Chef yum cache
+  ruby_block "yum-cache-reload-#{filename}" do
+    block { Chef::Provider::Package::Yum::YumCache.instance.reload }
+    action :nothing
+  end
+end
+
+def install_gem
+  base_url = new_resource.base_url
+
+  repo_url = construct_uri_with_options({base_url: base_url, repo: new_resource.repository})
+  repo_url = read_token(repo_url, true).to_s
+
+
+  execute "install packagecloud #{new_resource.name} repo as gem source" do
+    command "gem source --add #{repo_url}"
+    not_if "gem source --list | grep #{repo_url}"
+  end
+end
+
+
+def read_token(repo_url, gems=false)
+  return repo_url unless new_resource.master_token
+
+  base_url = new_resource.base_url
+
+  base_repo_url = ::File.join(base_url, node['packagecloud']['base_repo_path'])
+
+  uri = construct_uri_with_options({base_url: base_repo_url, repo: new_resource.repository, endpoint: 'tokens.text'})
+  uri.user     = new_resource.master_token
+  uri.password = ''
+
+  resp = post(uri, install_endpoint_params)
+
+  Chef::Log.debug("#{new_resource.name} TOKEN = #{resp.body.chomp}")
+
+  if is_rhel5? && !gems
+    repo_url
+  else
+    repo_url.user     = resp.body.chomp
+    repo_url.password = ''
+    repo_url
+  end
+end
+
+def install_endpoint_params
+  dist = new_resource.force_dist || value_for_platform_family(
+    'debian' => node['lsb']['codename'],
+    ['rhel', 'fedora'] => node['platform_version'],
+  )
+
+  hostname = node['packagecloud']['hostname_override'] ||
+             node['fqdn'] ||
+             node['hostname']
+
+  if !hostname || hostname.empty?
+    raise("Can't determine hostname!  Set node['packagecloud']['hostname_override'] " \
+          "if it cannot be automatically determined by Ohai.")
+  end
+
+  { :os   => os_platform,
+    :dist => dist,
+    :name => hostname }
+end
+
+def os_platform
+  new_resource.force_os || node['platform']
+end
+
+def filename
+  new_resource.name.gsub(/[^0-9A-z.\-]/, '_')
+end
+
+def is_rhel5?
+  platform_family?('rhel') && node['platform_version'].to_i == 5
+end
+
+def construct_uri_with_options(options)
+  required_options = [:base_url, :repo]
+
+  required_options.each do |opt|
+    if !options[opt]
+      raise ArgumentError,
+            "A required option :#{opt} was not specified"
+    end
+  end
+
+  options[:base_url] = append_trailing_slash(options[:base_url])
+  options[:repo]     = append_trailing_slash(options[:repo])
+
+  URI.join(options.delete(:base_url), options.inject([]) {|mem, opt| mem << opt[1]}.join)
+end
+
+def append_trailing_slash(str)
+  str.end_with?("/") ? str : str + "/"
+end

--- a/cookbooks/packagecloud/resources/repo.rb
+++ b/cookbooks/packagecloud/resources/repo.rb
@@ -1,0 +1,11 @@
+actions :add
+default_action :add
+
+attribute :repository,      :kind_of => String, :name_attribute => true
+attribute :master_token,    :kind_of => String
+attribute :force_os,        :kind_of => String
+attribute :force_dist,      :kind_of => String
+attribute :type,            :kind_of => String, :equal_to => ['deb', 'rpm', 'gem'], :default => node['packagecloud']['default_type']
+attribute :base_url,        :kind_of => String, :default => "https://packagecloud.io"
+attribute :priority,        :kind_of => [Fixnum, TrueClass, FalseClass], :default => false
+attribute :metadata_expire, :kind_of => String, :regex => [/^\d+[d|h|m]?$/], :default => "300"

--- a/cookbooks/packagecloud/templates/default/apt.erb
+++ b/cookbooks/packagecloud/templates/default/apt.erb
@@ -1,0 +1,2 @@
+deb <%= @base_url %> <%= @distribution %> <%= @component %>
+deb-src <%= @base_url %> <%= @distribution %> <%= @component %>

--- a/cookbooks/packagecloud/templates/default/yum.erb
+++ b/cookbooks/packagecloud/templates/default/yum.erb
@@ -1,0 +1,15 @@
+[<%= @name %>]
+name=<%= @description %>
+baseurl=<%= @base_url %>
+repo_gpgcheck=<%= @repo_gpgcheck %>
+<% if @priority -%>
+priority=<%=@priority %>
+<% end -%>
+gpgcheck=0
+enabled=1
+gpgkey=<%= @gpg_url %>
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+<% if @metadata_expire %>
+metadata_expire=<%= @metadata_expire %>
+<% end %>

--- a/cookbooks/simplerock/metadata.rb
+++ b/cookbooks/simplerock/metadata.rb
@@ -1,12 +1,12 @@
 name 'simplerock'
-maintainer 'Blackops.blue'
-maintainer_email 'webmaster@blackops.blue'
+maintainer 'rocknsm.io'
+maintainer_email 'jeff@rocknsm.io'
 license 'all_rights'
 description 'Installs/Configures a simple version of ROCK'
-long_description 'Installs/Configures a simple vrsion of ROCK'
-version '0.1.0'
+long_description 'Installs/Configures a simple version of ROCK'
+version '0.1.1'
 
 depends 'yum', '~> 3.6.1'
-#depends 'packagecloud'
+depends 'packagecloud'
 ## Tabled for now, using dcode's java headless package
 #depends 'java', '~> 1.0'

--- a/cookbooks/simplerock/templates/default/GeoIP.conf.erb
+++ b/cookbooks/simplerock/templates/default/GeoIP.conf.erb
@@ -1,0 +1,25 @@
+# If you purchase a subscription to the GeoIP database,
+# then you will obtain a license key which you can
+# use to automatically obtain updates.
+# for more details, please go to
+# http://www.maxmind.com/en/geolocation_landing
+
+# HowTo configure geoipupdate
+# http://www.maxmind.com/en/license_key
+
+# customer find the user_id and license key here:
+# https://www.maxmind.com/en/my_license_key
+#
+# UserId, and available ProductIds
+
+# Enter your license key here
+# customers should insert their license key and user_id
+# free GeoLite users should use 000000000000 as license key
+LicenseKey 000000000000
+
+# Enter your User ID here ( GeoLite only users should use 999999 as user_id )
+UserId 999999
+
+# Enter the Product ID(s) of the database(s) you would like to update
+# By default 106 (MaxMind GeoIP Country) is listed below
+ProductIds GeoLite-Legacy-IPv6-City GeoLite-Legacy-IPv6-Country 506 517 533

--- a/cookbooks/simplerock/templates/default/es_cleanup.sh.erb
+++ b/cookbooks/simplerock/templates/default/es_cleanup.sh.erb
@@ -8,8 +8,11 @@ done
 #Cleanup TopBeats indexes from 5 days ago.
 #curl -sSL -XDELETE "http://127.0.0.1:9200/topbeat-$(date -d '5 days ago' +%Y.%m.%d)" 2>&1
 
-#Delete Logstash indexes from 30 days ago.
-curl -sSL -XDELETE "http://127.0.0.1:9200/logstash-$(date -d '30 days ago' +%Y.%m.%d)" 2>&1
+#Delete Logstash indexes from 60 days ago.
+curl -sSL -XDELETE "http://127.0.0.1:9200/logstash-$(date -d '60 days ago' +%Y.%m.%d)" 2>&1
+
+#Close Logstash indexes from 15 days ago.
+curl -XPOST "http://127.0.0.1:9200/logstash-$(date -d '15 days ago' +%Y.%m.%d)/_close" 2>&1
 
 #Make sure all indexes have replicas off
 curl -sSL -XPUT 'localhost:9200/_all/_settings' -d '

--- a/cookbooks/simplerock/templates/default/nginx.conf.erb
+++ b/cookbooks/simplerock/templates/default/nginx.conf.erb
@@ -1,0 +1,34 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+#   * Official Russian Documentation: http://nginx.org/ru/docs/
+
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/cookbooks/simplerock/templates/default/snort.conf.erb
+++ b/cookbooks/simplerock/templates/default/snort.conf.erb
@@ -249,10 +249,10 @@ config paf_max: 16000
 ###################################################
 
 # path to dynamic preprocessor libraries
-dynamicpreprocessor directory /usr/lib64/snort-2.9.8.0_dynamicpreprocessor/
+dynamicpreprocessor directory /usr/lib64/snort-2.9.8.3_dynamicpreprocessor/
 
 # path to base preprocessor engine
-dynamicengine /usr/lib64/snort-2.9.8.0_dynamicengine/libsf_engine.so
+dynamicengine /usr/lib64/snort-2.9.8.3_dynamicengine/libsf_engine.so
 
 # path to dynamic rules libraries
 # dynamicdetection directory /usr/lib/snort_dynamicrules
@@ -526,8 +526,9 @@ preprocessor reputation: \
 #output unified2: filename merged.log, limit 128, nostamp, mpls_event_types, vlan_event_types
 
 # Additional configuration for specific types of installs
-output alert_unified2: filename snort.alert, limit 128, nostamp
+#output alert_unified2: filename snort.alert, limit 128, nostamp
 # output log_unified2: filename snort.log, limit 128, nostamp 
+output alert_unified2: filename snort.alert, limit 10
 
 # syslog
 # output alert_syslog: LOG_AUTH LOG_ALERT

--- a/cookbooks/simplerock/templates/default/snort_cleanup.sh.erb
+++ b/cookbooks/simplerock/templates/default/snort_cleanup.sh.erb
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+COUNT=$(ls -ltr /data/snort/snort.alert.* | awk '{print $NF}' | wc -l)
+OLDCOUNT=$(( COUNT - 1 ))
+
+for i in $(ls -ltr /data/snort/snort.alert.* | awk '{print $NF}' | head -$OLDCOUNT); do
+  #DEBUG
+  #echo $i
+  mv "$i" /data/snort/OLD/
+done
+
+exit 0


### PR DESCRIPTION
 * Packages moved to packagecloud.io

 *  Fixes for bro and snort integration via the unified2 file reader

 *  Bro version pinned to 2.4.1 until the beta solidifies

 *  Fixes to make GeoIP work reliably

 *  Updated the es_cleanup.sh so it closes indexes after 15 days and deletes them after 60. (As an example)