### PR TITLE
Temporary gpgcheck workaround for local

### DIFF
--- a/playbooks/roles/sensor-common/tasks/configure.yml
+++ b/playbooks/roles/sensor-common/tasks/configure.yml
@@ -181,9 +181,9 @@
     name: rocknsm-local
     description: ROCKNSM Local Repository
     baseurl: "{{ rocknsm_local_baseurl }}"
-    gpgcheck: 1
+    gpgcheck: 0
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-RockNSM-2
-    repo_gpgcheck: 1
+    repo_gpgcheck: 0
     cost: 500
   when: "{{ not rock_online_install | bool }}"
 


### PR DESCRIPTION
Currently, testing ISOs generated w/o the RockNSM GPG keys fail to progress due to missing signed repodata. This is a temporary work around that @jeffgeiger is working on a better fix.