### PR TITLE
Prevent rock from overwriting the version file

### DIFF
--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -3,7 +3,7 @@
 http_proxy: "{{ lookup('env','http_proxy') }}"
 https_proxy: "{{ lookup('env', 'https_proxy') }}"
 
-rock_version: {{ lookup('file', '/etc/rocknsm/rock-version', errors='ignore') | default('2.5.0') }}
+rock_version: "{{ lookup('file', '/etc/rocknsm/rock-version', errors='ignore') | default('2.5.0') }}"
 elastic:
   major_version: 7
   suffix: "x"


### PR DESCRIPTION
Updates default version string to 2.5.0. It'd be nice to somehow capture this at package time and/or git version 🤷‍♂ .