### PR TITLE
Replaced shell and pipes with single awk command

### DIFF
--- a/roles/bro/tasks/main.yml
+++ b/roles/bro/tasks/main.yml
@@ -288,7 +288,9 @@
   when: (default_mount is defined and item.mount == default_mount and rock_mounts is not defined)
 
 - name: Determining if quotas are enabled
-  shell: grep "{{ default_mount }}" /etc/fstab | awk /prjquota/
+  command: >
+    awk -v path="{{ default_mount }}"
+      '$2 ~ path && $4 ~ /p(rj)?quota/ ' /etc/fstab
   register: prjquota
   changed_when: false
 

--- a/roles/elasticsearch/tasks/before.yml
+++ b/roles/elasticsearch/tasks/before.yml
@@ -69,7 +69,9 @@
   when: (default_mount is defined and item.mount == default_mount and rock_mounts is not defined)
 
 - name: Determining if quotas are enabled
-  shell: grep "{{ default_mount }}" /etc/fstab | awk /prjquota/
+  command: >
+    awk -v path="{{ default_mount }}"
+      '$2 ~ path && $4 ~ /p(rj)?quota/ ' /etc/fstab
   register: prjquota
   changed_when: false
 

--- a/roles/fsf/tasks/main.yml
+++ b/roles/fsf/tasks/main.yml
@@ -58,7 +58,9 @@
   when: (default_mount is defined and item.mount == default_mount and rock_mounts is not defined)
 
 - name: Determining if quotas are enabled
-  shell: grep "{{ default_mount }}" /etc/fstab | awk /prjquota/
+  command: >
+    awk -v path="{{ default_mount }}"
+      '$2 ~ path && $4 ~ /p(rj)?quota/ ' /etc/fstab
   register: prjquota
   changed_when: false
 

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -39,7 +39,9 @@
   when: (default_mount is defined and item.mount == default_mount and rock_mounts is not defined)
 
 - name: Determining if quotas are enabled
-  shell: grep "{{ default_mount }}" /etc/fstab | awk /prjquota/
+  command: >
+    awk -v path="{{ default_mount }}"
+      '$2 ~ path && $4 ~ /p(rj)?quota/ ' /etc/fstab
   register: prjquota
   changed_when: false
 

--- a/roles/stenographer/tasks/config.yml
+++ b/roles/stenographer/tasks/config.yml
@@ -51,7 +51,9 @@
   when: (default_mount is defined and item.mount == default_mount and rock_mounts is not defined)
 
 - name: Determining if quotas are enabled
-  shell: grep "{{ default_mount }}" /etc/fstab | awk /prjquota/
+  command: >
+    awk -v path="{{ default_mount }}"
+      '$2 ~ path && $4 ~ /p(rj)?quota/ ' /etc/fstab
   register: prjquota
   changed_when: false
 

--- a/roles/suricata/tasks/main.yml
+++ b/roles/suricata/tasks/main.yml
@@ -102,7 +102,9 @@
   when: (default_mount is defined and item.mount == default_mount and rock_mounts is not defined)
 
 - name: Determining if quotas are enabled
-  shell: grep "{{ default_mount }}" /etc/fstab | awk /prjquota/
+  command: >
+    awk -v path="{{ default_mount }}"
+      '$2 ~ path && $4 ~ /p(rj)?quota/ ' /etc/fstab
   register: prjquota
   changed_when: false
 


### PR DESCRIPTION
Previously used `shell` module and piped two commands together. That's not inherently a problem, unless the first command fails, then the second command may still return 0. Ansible couldn't detect a failure in this case. You can fix that by setting `set -o pipefail`, except `grep` returns a non-zero status if there is no match, thus always failing. Since we're using `awk` anyway, I just dropped grep altogether and asked awk to match the line.